### PR TITLE
Catch & log errors during config polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 # Consultant
 ###### Fetches your service's configuration from Consul, and subscribes to any changes.
 
+## Install
+
+```js
+npm install @magnet.me/consultant
+```
+
 ## What's Consultant?
 Consultant is a Node library which allows your service to retrieve its configuration from Consul's Key/Value store as well as registering services. In addition to this, Consultant subscribes to any changes relevant to your service.
 
@@ -32,7 +38,7 @@ Or alternatively you can also define the this through an environment variable:
 ## Listening for config updates
 `config` returns a promise which when resolved contains an object that allows consumers to register to updates in their configuration. This approach allows consumers to directly fetch the configuration, or subscribe to any changes made. For example:
 ```javascript
-import {config} from 'consultant';
+import {config} from '@magnet.me/consultant';
 
 const {register, getProperties} = await config({service:{name:'test-server'}});
 

--- a/src/config.js
+++ b/src/config.js
@@ -69,8 +69,12 @@ export default async function initializeConfiguration({consulHost, service, pref
 	let timerId;
 	if (interval > 0) {
 		timerId = setInterval(async () => {
-			const newProperties = await loadConfig(consulHost, prefix, identifier);
-			updateConfig(liveProperties, newProperties, callbacks);
+			try {
+				const newProperties = await loadConfig(consulHost, prefix, identifier);
+				updateConfig(liveProperties, newProperties, callbacks);
+			} catch(e) {
+				console.warn('Could not fetch new properties from consul', e);
+			}
 		}, interval);
 	}
 


### PR DESCRIPTION
If we don't catch the errors then they will end up in the
`unhandledPromiseRejection` callbacks from users of this library, where
it's difficult to process them. We now catch the error and log it
instead.

Fly-by:
- Add install instructions in the README

@Magnetme/monolith - RFR