### PR TITLE
Ensure the consultant client fires request to the Consul API using the appropriate HTTP verb

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -7,7 +7,7 @@ import fetchIdentifier from './identifier';
 const deregister = async (host, instance) => {
 	const req = {
 		url : `${host}/v1/agent/service/deregister/${instance.instance}`,
-		method : 'DELETE',
+		method : 'PUT',
 		headers : {
 			'user-agent' : properties.userAgent
 		}


### PR DESCRIPTION
[Deregisters now use a PUT instead of a GET](https://www.consul.io/api/agent/service.html#deregister-service)

Not sure why its not a really restful API by using a DELETE, but let's just conform!

I'll update the version one this PR landed on master