### PR TITLE
Catch thrown exceptions in config updater

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -45,6 +45,11 @@ const configUpdater = (consulHost, prefix, service, callback) => {
 					callback(properties);
 				}
 			}
+			catch (e) {
+				timeout = 5000;
+				// eslint-disable-next-line no-console
+				console.warn(`Error retrieving data from Consul: ${e}`);
+			}
 			finally {
 				if (!shutdown) {
 					timeoutId = setTimeout(self.poll, timeout);


### PR DESCRIPTION
If e.g. `fetch` throws, just wait a few seconds and retry again. Generally it would throw over something temporary, just as DNS resolving issues.