### PR TITLE
Switch to crypto for `uuid` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "atob": "^2.0.3",
-    "node-fetch": "^2.6.7",
-    "uuid": "^7.0.3"
+    "node-fetch": "^2.6.7"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/src/identifier.js
+++ b/src/identifier.js
@@ -1,5 +1,5 @@
 import fetchAgent from './agent';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 
 export default async function loadIdentifier(identifier, consulHost) {
 	const agent = await fetchAgent(consulHost);
@@ -8,6 +8,6 @@ export default async function loadIdentifier(identifier, consulHost) {
 		name : identifier.name || process.env.SERVICE_NAME,
 		dataCenter : identifier.dataCenter || process.env.SERVICE_DC || agent.Config.Datacenter,
 		host : identifier.host || process.env.SERVICE_HOST || agent.Config.NodeName,
-		instance : identifier.instance || process.env.SERVICE_INSTANCE || uuidv4(),
+		instance : identifier.instance || process.env.SERVICE_INSTANCE || randomUUID(),
 	};
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3232,11 +3232,6 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
-
 v8-compile-cache@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"


### PR DESCRIPTION
It is no longer necessary to include this package for uuid generation. Additionally this silences a Dependabot alert in all downstream services